### PR TITLE
Derive Debug, Copy and Clone traits for XngHypervisor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cty = "*"
 apex-rs = { git = "https://github.com/aeronautical-informatics/apex-rs.git", branch = "main", features = ["strum"] }
+log = "0"

--- a/src/apex/error.rs
+++ b/src/apex/error.rs
@@ -1,6 +1,7 @@
 use core::mem::MaybeUninit;
 
 use apex_rs::bindings::*;
+use log::trace;
 
 use super::XngHypervisor;
 use crate::bindings::*;

--- a/src/apex/mod.rs
+++ b/src/apex/mod.rs
@@ -14,4 +14,5 @@ pub mod schedules;
 pub mod time;
 
 /// Static struct representing a Xng Hypervisor
+#[derive(Debug, Clone, Copy)]
 pub struct XngHypervisor;

--- a/src/apex/process.rs
+++ b/src/apex/process.rs
@@ -11,7 +11,7 @@ impl ApexProcessP4 for XngHypervisor {
     ) -> Result<ProcessId, ErrorReturnCode> {
         let mut return_code = MaybeUninit::uninit();
         let mut process_id = MaybeUninit::uninit();
-        if attributes.name[31..=32] != [0, 0] {
+        if attributes.name[31..32] != [0, 0] {
             return Err(ErrorReturnCode::InvalidParam);
         }
         let mut name = [0 as cty::c_char; 30];

--- a/src/apex/process.rs
+++ b/src/apex/process.rs
@@ -11,7 +11,8 @@ impl ApexProcessP4 for XngHypervisor {
     ) -> Result<ProcessId, ErrorReturnCode> {
         let mut return_code = MaybeUninit::uninit();
         let mut process_id = MaybeUninit::uninit();
-        if attributes.name[31..32] != [0, 0] {
+        if attributes.name[30..32] != [0, 0] {
+            log::error!("Blaaaaa: {:?}", attributes.name);
             return Err(ErrorReturnCode::InvalidParam);
         }
         let mut name = [0 as cty::c_char; 30];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,12 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         None => "panic of unknown cause occured",
     };
 
-    log::error!("Paniced: {}", message);
+    let (file, line) = match info.location() {
+        Some(location) => (location.file(), location.line()),
+        None => ("unknown location", 0),
+    };
+
+    log::error!("{} in {}:{}", message, file, line);
 
     // // This function can fail if the message len in bytes is longer than
     // // MAX_ERROR_MESSAGE_SIZE. To make it safe to unwrap, we have to shorten

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         None => "panic of unknown cause occured",
     };
 
-    let (file, line) = match info.location() {
-        Some(location) => (location.file(), location.line()),
-        None => ("unknown location", 0),
-    };
-
-    log::error!("{} in {}:{}", message, file, line);
+    log::error!("panic: {}", info);
 
     // // This function can fail if the message len in bytes is longer than
     // // MAX_ERROR_MESSAGE_SIZE. To make it safe to unwrap, we have to shorten

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,15 +27,17 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         None => "panic of unknown cause occured",
     };
 
-    // This function can fail if the message len in bytes is longer than
-    // MAX_ERROR_MESSAGE_SIZE. To make it safe to unwrap, we have to shorten
-    // the message if it exceeds the allowed length. As the slicing only happen
-    // on the byte level, cutting of a multi-byte char (UTF-8) will not yield
-    // internal panic, but of course it might disturb the hypervisors output.
-    <apex::XngHypervisor as apex_rs::prelude::ApexErrorP4Ext>::raise_application_error(
-        &message.as_bytes()[0..bindings::MAX_ERROR_MESSAGE_SIZE as usize],
-    )
-    .unwrap();
+    log::error!("Paniced: {}", message);
+
+    // // This function can fail if the message len in bytes is longer than
+    // // MAX_ERROR_MESSAGE_SIZE. To make it safe to unwrap, we have to shorten
+    // // the message if it exceeds the allowed length. As the slicing only happen
+    // // on the byte level, cutting of a multi-byte char (UTF-8) will not yield
+    // // internal panic, but of course it might disturb the hypervisors output.
+    let bytes = message.as_bytes();
+    let bytes = &bytes[0..(core::cmp::min(bindings::MAX_ERROR_MESSAGE_SIZE as usize, bytes.len()))];
+    <apex::XngHypervisor as apex_rs::prelude::ApexErrorP4Ext>::raise_application_error(bytes)
+        .unwrap();
 
     loop {}
 }


### PR DESCRIPTION
This adds derived implementations for Debug, Copy and Clone for the XngHypervisor struct. This way, it can be used as a generic Argument to Types that implement Debug, Copy or Clone.

I ran into problems while unwrapping on a `Result<apex_rs::prelude::SamplingPortDestination<100, XngHypervisor>, Error>` and cloning the result.